### PR TITLE
Adjustments to #387 (events)

### DIFF
--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -22,7 +22,13 @@ from ._custom_types import (
     SpaceTimeTimeLevyArea as SpaceTimeTimeLevyArea,
 )
 from ._event import (
+    # Deliberately not provided with `X as X` as these are now deprecated, so we'd like
+    # static type checkers to warn about using them.
+    AbstractDiscreteTerminatingEvent,  # noqa: F401
+    DiscreteTerminatingEvent,  # noqa: F401
     Event as Event,
+    steady_state_event as steady_state_event,
+    SteadyStateEvent,  # noqa: F401
 )
 from ._global_interpolation import (
     AbstractGlobalInterpolation as AbstractGlobalInterpolation,

--- a/diffrax/_event.py
+++ b/diffrax/_event.py
@@ -1,13 +1,116 @@
+import abc
 from collections.abc import Callable
 from typing import Optional, Union
 
 import equinox as eqx
 import optimistix as optx
-from jaxtyping import PyTree
+from jaxtyping import Array, PyTree
 
-from ._custom_types import BoolScalarLike, RealScalarLike
+from ._custom_types import BoolScalarLike, FloatScalarLike, RealScalarLike
+from ._step_size_controller import AbstractAdaptiveStepSizeController
 
 
 class Event(eqx.Module):
     cond_fn: PyTree[Callable[..., Union[BoolScalarLike, RealScalarLike]]]
     root_finder: Optional[optx.AbstractRootFinder] = None
+
+
+def steady_state_event(
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+    norm: Optional[Callable[[PyTree[Array]], RealScalarLike]] = None,
+):
+    """Create a [`diffrax.Event`][] that terminates the solve once a steady state is
+    achieved.
+
+    **Arguments:**
+
+    - `rtol`, `atol`, `norm`: the solve will terminate once
+        `norm(f) < atol + rtol * norm(y)`, where `f` is the result of evaluating the
+        vector field. Will default to the values used in the `stepsize_controller` if
+        they are not specified here.
+
+    **Returns:**
+
+    A [`diffrax.Event`][] object, that can be passed to
+    `diffrax.diffeqsolve(..., event=...)`.
+    """
+
+    def _cond_fn(t, y, args, *, terms, solver, stepsize_controller, **kwargs):
+        del kwargs
+        msg = (
+            "The `rtol`, `atol`, and `norm` for `steady_state_event` default to the "
+            "values used with an adaptive step size controller (such as "
+            "`diffrax.PIDController`). Either use an adaptive step size controller, or "
+            "specify these tolerances manually."
+        )
+        if rtol is None:
+            if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+                _rtol = stepsize_controller.rtol
+            else:
+                raise ValueError(msg)
+        else:
+            _rtol = rtol
+        if atol is None:
+            if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+                _atol = stepsize_controller.atol
+            else:
+                raise ValueError(msg)
+        else:
+            _atol = atol
+        if norm is None:
+            if isinstance(stepsize_controller, AbstractAdaptiveStepSizeController):
+                _norm = stepsize_controller.norm
+            else:
+                raise ValueError(msg)
+        else:
+            _norm = norm
+
+        # TODO: this makes an additional function evaluation that in practice has
+        # probably already been made by the solver.
+        vf = solver.func(terms, t, y, args)
+        return _norm(vf) < _atol + _rtol * _norm(y)
+
+    return Event(cond_fn=_cond_fn)
+
+
+#
+# Backward compatibility: continue to support `AbstractDiscreteTerminatingEvent`.
+# TODO: eventually remove everything below this line.
+#
+
+
+class AbstractDiscreteTerminatingEvent(eqx.Module):
+    @abc.abstractmethod
+    def __call__(self, state, **kwargs) -> BoolScalarLike:
+        pass
+
+
+class DiscreteTerminatingEvent(AbstractDiscreteTerminatingEvent):
+    cond_fn: Callable[..., BoolScalarLike]
+
+    def __call__(self, state, **kwargs):
+        return self.cond_fn(state, **kwargs)
+
+
+class SteadyStateEvent(AbstractDiscreteTerminatingEvent):
+    rtol: Optional[float] = None
+    atol: Optional[float] = None
+    norm: Callable[[PyTree[Array]], RealScalarLike] = optx.rms_norm
+
+    def __call__(self, state, *, args, **kwargs):
+        return steady_state_event(self.rtol, self.atol, self.norm).cond_fn(
+            state.tprev, state.y, args, **kwargs
+        )
+
+
+class _StateCompat(eqx.Module):
+    tprev: FloatScalarLike
+    y: PyTree[Array]
+
+
+class DiscreteTerminatingEventToCondFn(eqx.Module):
+    event: AbstractDiscreteTerminatingEvent
+
+    def __call__(self, t, y, args, **kwargs):
+        return self.event(_StateCompat(tprev=t, y=y), args=args, **kwargs)

--- a/diffrax/_global_interpolation.py
+++ b/diffrax/_global_interpolation.py
@@ -40,7 +40,7 @@ class AbstractGlobalInterpolation(AbstractPath):
     ) -> tuple[IntScalarLike, RealScalarLike]:
         maxlen = self.ts_size - 2
         index = jnp.searchsorted(self.ts, t, side="left" if left else "right")
-        index = jnp.clip(index - 1, a_min=0, a_max=maxlen)
+        index = jnp.clip(index - 1, min=0, max=maxlen)
         # Will never access the final element of `ts`; this is correct behaviour.
         fractional_part = t - self.ts[index]
         return index, fractional_part

--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -16,6 +16,7 @@ import equinox as eqx
 import equinox.internal as eqxi
 import jax
 import jax.core
+import jax.lax as lax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import lineax.internal as lxi
@@ -31,7 +32,11 @@ from ._custom_types import (
     IntScalarLike,
     RealScalarLike,
 )
-from ._event import Event
+from ._event import (
+    AbstractDiscreteTerminatingEvent,
+    DiscreteTerminatingEventToCondFn,
+    Event,
+)
 from ._global_interpolation import DenseInterpolation
 from ._heuristics import is_sde, is_unsafe_sde
 from ._misc import linear_rescale, static_select
@@ -70,35 +75,45 @@ class SaveState(eqx.Module):
 
 
 class State(eqx.Module):
+    #
     # Evolving state during the solve
+    #
     y: PyTree[Array]
     tprev: FloatScalarLike
     tnext: FloatScalarLike
     made_jump: BoolScalarLike
     solver_state: PyTree[ArrayLike]
     controller_state: PyTree[ArrayLike]
+    progress_meter_state: PyTree[Array]
     result: RESULTS
+    #
+    # Reported output statistics
+    #
     num_steps: IntScalarLike
     num_accepted_steps: IntScalarLike
     num_rejected_steps: IntScalarLike
+    #
     # Output that is .at[].set() updated during the solve (and their indices)
+    #
     save_state: PyTree[SaveState]
     dense_ts: Optional[eqxi.MaybeBuffer[Float[Array, " times_plus_1"]]]
     dense_infos: Optional[BufferDenseInfos]
     dense_save_index: Optional[IntScalarLike]
-    progress_meter_state: PyTree[Array]
-    event_result: Optional[PyTree[Union[BoolScalarLike, RealScalarLike]]]
+    #
+    # Information about the most recent step, used for events.
+    #
+    # Not recorded anywhere else: this is the previous state's `tprev`.
+    event_tprev: Optional[FloatScalarLike]
+    # This is the previous state's `tnext`. This is not necessarily the same as our
+    # `tprev`, as the two can differ a little bit when crossing jumps.
+    event_tnext: Optional[FloatScalarLike]
+    event_dense_info: Optional[DenseInfo]
+    event_values: Optional[PyTree[Union[BoolScalarLike, RealScalarLike]]]
     event_mask: Optional[PyTree[BoolScalarLike]]
-    dense_info_for_event: Optional[DenseInfo]
-    tprevprev: Optional[FloatScalarLike]
 
 
 def _is_none(x: Any) -> bool:
     return x is None
-
-
-def _is_bool(x: Any) -> bool:
-    return isinstance(x, BoolScalarLike)
 
 
 def _term_compatible(
@@ -246,36 +261,6 @@ def _maybe_static(static_x: Optional[ArrayLike], x: ArrayLike) -> ArrayLike:
         return x
 
 
-def _compare_events(
-    old_event_result: Union[BoolScalarLike, RealScalarLike],
-    new_event_result: Union[BoolScalarLike, RealScalarLike],
-) -> BoolScalarLike:
-    with jax.numpy_dtype_promotion("standard"):
-        old_dtype = jnp.result_type(jnp.array(old_event_result), jnp.float32)
-        new_dtype = jnp.result_type(jnp.array(new_event_result), jnp.float32)
-        old_sign = jnp.sign(jnp.array(old_event_result, dtype=old_dtype))
-        new_sign = jnp.sign(jnp.array(new_event_result, dtype=new_dtype))
-    return old_sign != new_sign
-
-
-def _event_happened(event_mask: PyTree[BoolScalarLike]) -> BoolScalarLike:
-    return jnp.any(jnp.array(jtu.tree_leaves(event_mask)))
-
-
-@jax.custom_jvp
-def _bool_event_gradient(t: RealScalarLike, result: BoolScalarLike) -> FloatScalarLike:
-    return jnp.where(result, 0.0, 1.0)
-
-
-@_bool_event_gradient.defjvp
-def _bool_event_gradient_jvp(primals, tangents):
-    t, result = primals
-    tangent_t, _ = tangents
-    out = _bool_event_gradient(t, result)
-    tangent_out = 1.0
-    return out, tangent_out
-
-
 _PRINT_STATIC = False  # used in tests
 
 
@@ -357,14 +342,6 @@ def loop(
         # we get a negative value for y, and then get a NaN vector field. (And then
         # everything breaks.) See #143.
         y_error = jtu.tree_map(lambda x: jnp.where(jnp.isnan(x), jnp.inf, x), y_error)
-
-        # Save info for event handling
-        if event is None:
-            tprevprev = None
-            dense_info_for_event = None
-        else:
-            tprevprev = state.tprev
-            dense_info_for_event = dense_info
 
         error_order = solver.error_order(terms)
         (
@@ -509,6 +486,76 @@ def loop(
             )
             dense_save_index = dense_save_index + jnp.where(keep_step, 1, 0)
 
+        if event is None:
+            event_tprev = None
+            event_tnext = None
+            event_dense_info = None
+            event_values = None
+            event_mask = None
+        else:
+            event_tprev = state.tprev
+            event_tnext = state.tnext
+            event_dense_info = dense_info
+            event_values = jtu.tree_map(
+                lambda cond_fn_i: cond_fn_i(
+                    tprev,
+                    y,
+                    args,
+                    terms=terms,
+                    solver=solver,
+                    t0=t0,
+                    t1=t1,
+                    dt0=dt0,
+                    saveat=saveat,
+                    stepsize_controller=stepsize_controller,
+                    max_steps=max_steps,
+                ),
+                event.cond_fn,
+                is_leaf=callable,
+            )
+            had_event = False
+            old_event_values_leaves, old_event_structure = jtu.tree_flatten(
+                state.event_values
+            )
+            new_event_values_leaves, new_event_structure = jtu.tree_flatten(
+                event_values
+            )
+            assert old_event_structure == new_event_structure
+            event_mask_leaves = []
+            for old_event_value_i, new_event_value_i in zip(
+                old_event_values_leaves, new_event_values_leaves
+            ):
+                assert jnp.shape(old_event_value_i) == ()
+                if jnp.shape(new_event_value_i) != ():
+                    raise ValueError(
+                        "Event functions must return a scalar, got shape "
+                        f"{jnp.shape(new_event_value_i)}."
+                    )
+                old_dtype = jnp.result_type(old_event_value_i)
+                new_dtype = jnp.result_type(new_event_value_i)
+                if old_dtype != new_dtype:
+                    raise ValueError(
+                        "Event functions must consistently return either a boolean or "
+                        f"a float, got a change of dtype from {old_dtype} to "
+                        f"{new_dtype}."
+                    )
+                if jnp.issubdtype(new_dtype, jnp.floating):
+                    event_mask_i = jnp.sign(old_event_value_i) != jnp.sign(
+                        new_event_value_i
+                    )
+                elif jnp.issubdtype(new_dtype, jnp.bool_):
+                    event_mask_i = new_event_value_i
+                else:
+                    assert False
+                event_mask_leaves.append(event_mask_i & jnp.invert(had_event))
+                had_event = event_mask_i | had_event
+            event_mask = jtu.tree_unflatten(old_event_structure, event_mask_leaves)
+            result = RESULTS.where(
+                had_event,
+                RESULTS.terminating_event_occurred,
+                state.result,
+            )
+
         new_state = State(
             y=y,
             tprev=tprev,
@@ -521,60 +568,16 @@ def loop(
             num_accepted_steps=num_accepted_steps,
             num_rejected_steps=num_rejected_steps,
             save_state=save_state,
-            dense_ts=dense_ts,  # pyright: ignore
+            dense_ts=dense_ts,  # pyright: ignore[reportArgumentType]
             dense_infos=dense_infos,
             dense_save_index=dense_save_index,
             progress_meter_state=progress_meter_state,
-            dense_info_for_event=dense_info_for_event,
-            tprevprev=tprevprev,
-            event_result=None,
-            event_mask=None,
+            event_tprev=event_tprev,
+            event_tnext=event_tnext,
+            event_dense_info=event_dense_info,
+            event_values=event_values,
+            event_mask=event_mask,
         )
-
-        if event is not None:
-
-            def _call_event(_cond_fn):
-                return _cond_fn(
-                    new_state,
-                    y=y,
-                    solver=solver,
-                    stepsize_controller=stepsize_controller,
-                    saveat=saveat,
-                    t0=t0,
-                    t1=t1,
-                    dt0=dt0,
-                    max_steps=max_steps,
-                    terms=terms,
-                    args=args,
-                )
-
-            event_result = jtu.tree_map(_call_event, event.cond_fn, is_leaf=callable)
-            event_mask = jtu.tree_map(_compare_events, state.event_result, event_result)
-            result = RESULTS.where(
-                _event_happened(event_mask),
-                RESULTS.discrete_terminating_event_occurred,
-                result,
-            )
-            # If multiple events are triggered in one step we take the first one
-            event_hist = []
-
-            def counter_update(x):
-                out = jnp.where(jnp.any(jnp.array(event_hist)), False, x)
-                event_hist.append(x)
-                return out
-
-            event_mask = jtu.tree_map(counter_update, event_mask, is_leaf=_is_bool)
-
-            new_state = eqx.tree_at(lambda s: s.result, new_state, result)
-            new_state = eqx.tree_at(
-                lambda s: s.event_result, new_state, event_result, is_leaf=_is_none
-            )
-            new_state = eqx.tree_at(
-                lambda s: s.event_mask,
-                new_state,
-                event_mask,
-                is_leaf=_is_none,
-            )
 
         return (
             new_state,
@@ -606,16 +609,113 @@ def loop(
     final_state = outer_while_loop(
         cond_fun, body_fun, init_state, max_steps=max_steps, buffers=_outer_buffers
     )
+    result = final_state.result
+
+    if event is None or event.root_finder is None:
+        tfinal = final_state.tprev
+        yfinal = final_state.y
+    else:
+        # If we're on this branch, it means that an event may have triggered, and now we
+        # may need to do a root find, in order to locate the event time.
+        event_mask = final_state.event_mask
+        flat_mask = jtu.tree_leaves(event_mask)
+        assert all(jnp.shape(x) == () for x in flat_mask)
+        event_happened = jnp.any(jnp.stack(flat_mask))
+
+        def _root_find():
+            _interpolator = solver.interpolation_cls(
+                t0=final_state.event_tprev,
+                t1=final_state.event_tnext,
+                **final_state.event_dense_info,
+            )
+
+            def _to_root_find(_t, _):
+                _distance_from_t_end = final_state.event_tnext - _t
+
+                def _call_real(_event_mask_i, _cond_fn_i):
+                    def _call_real_impl():
+                        # First evaluate the triggered event.
+                        _y = _interpolator.evaluate(_t)
+                        _value = _cond_fn_i(
+                            t=_t,
+                            y=_y,
+                            args=args,
+                            terms=terms,
+                            solver=solver,
+                            t0=t0,
+                            t1=t1,
+                            dt0=dt0,
+                            saveat=saveat,
+                            stepsize_controller=stepsize_controller,
+                            max_steps=max_steps,
+                        )
+                        # Second: if this is a boolean event, then normalise to a
+                        # floating point number by having the root occur at the end of
+                        # the last step, i.e. `event_tnext`.
+                        _value_dtype = jnp.result_type(_value)
+                        if jnp.issubdtype(_value_dtype, jnp.bool_):
+                            _value = _distance_from_t_end
+                        else:
+                            assert jnp.issubdtype(_value_dtype, jnp.floating)
+                        return _value
+
+                    # Only the triggered event actually gets to the decide what time the
+                    # event occurs; everything else is zeroed out to automatically give
+                    # a root.
+                    #
+                    # We allow this `lax.cond` to be inefficiently transformed into a
+                    # `lax.select` when `_event_mask_i` is batched. There isn't any way
+                    # to avoid this, I think.
+                    _value = lax.cond(_event_mask_i, _call_real_impl, lambda: 0.0)
+
+                    # Third: if no events triggered at all, then has the root occur at
+                    # the end of the last step (which will be the `t1` of the overall
+                    # solve).
+                    _value = jnp.where(event_happened, _value, _distance_from_t_end)
+                    return _value
+
+                return jtu.tree_map(
+                    _call_real,
+                    event_mask,
+                    event.cond_fn,
+                )
+
+            _options = {
+                "lower": final_state.event_tprev,
+                "upper": final_state.event_tnext,
+            }
+            _event_root_find = optx.root_find(
+                _to_root_find,
+                event.root_finder,
+                y0=final_state.event_tnext,
+                options=_options,
+                throw=False,
+            )
+            _tfinal = _event_root_find.value
+            # TODO: we might need to change the way we evaluate `_yfinal` in order to
+            # get more accurate derivatives?
+            _yfinal = _interpolator.evaluate(_tfinal)
+            _result = RESULTS.where(
+                _event_root_find.result == optx.RESULTS.successful,
+                result,
+                RESULTS.promote(_event_root_find.result),
+            )
+            return _tfinal, _yfinal, _result
+
+        # Fastpath: if no event happened anywhere at all, then skip the root-find
+        # altogether.
+        # Note that `_root_find` might still be called on batch elements which did not
+        # have an event, so we still need to access `event_happened` inside of it.
+        tfinal, yfinal, result = lax.cond(
+            eqxi.unvmap_any(event_happened),
+            _root_find,
+            lambda: (final_state.tprev, final_state.y, result),
+        )
 
     def _save_t1(subsaveat, save_state):
         if subsaveat.t1 and not subsaveat.steps:
             # If subsaveat.steps then the final value is already saved.
-            #
-            # Use `tprev` instead of `t1` in case of an event terminating the solve
-            # early. (And absent such an event then `tprev == t1`.)
-            save_state = _save(
-                final_state.tprev, final_state.y, args, subsaveat.fn, save_state
-            )
+            save_state = _save(tfinal, yfinal, args, subsaveat.fn, save_state)
         return save_state
 
     save_state = jtu.tree_map(
@@ -626,10 +726,8 @@ def loop(
     )
 
     final_state = _handle_static(final_state)
-    result = RESULTS.where(
-        cond_fun(final_state), RESULTS.max_steps_reached, final_state.result
-    )
-    aux_stats = dict()
+    result = RESULTS.where(cond_fun(final_state), RESULTS.max_steps_reached, result)
+    aux_stats = dict()  # TODO: put something in here?
     return eqx.tree_at(lambda s: s.result, final_state, result), aux_stats
 
 
@@ -643,6 +741,7 @@ if not TYPE_CHECKING:
 
 
 @eqx.filter_jit
+@eqxi.doc_remove_args("discrete_terminating_event")
 def diffeqsolve(
     terms: PyTree[AbstractTerm],
     solver: AbstractSolver,
@@ -662,6 +761,8 @@ def diffeqsolve(
     solver_state: Optional[PyTree[ArrayLike]] = None,
     controller_state: Optional[PyTree[ArrayLike]] = None,
     made_jump: Optional[BoolScalarLike] = None,
+    # Exists for backward compatibility
+    discrete_terminating_event: Optional[AbstractDiscreteTerminatingEvent] = None,
 ) -> Solution:
     """Solves a differential equation.
 
@@ -706,8 +807,8 @@ def diffeqsolve(
         discretise-then-optimise, which is usually the best option for most problems.
         See the page on [Adjoints](./adjoints.md) for more information.
 
-    - `discrete_terminating_event`: A discrete event at which to terminate the solve
-        early. See the page on [Events](./events.md) for more information.
+    - `event`: An event at which to terminate the solve early. See the page on
+        [Events](./events.md) for more information.
 
     - `max_steps`: The maximum number of steps to take before quitting the computation
         unconditionally.
@@ -717,9 +818,7 @@ def diffeqsolve(
 
     - `throw`: Whether to raise an exception if the integration fails for any reason.
 
-        If `True` then an integration failure will raise an error. Note that the errors
-        are only reliably raised on CPUs. If on GPUs then the error may only be
-        printed to stderr, whilst on TPUs then the behaviour is undefined.
+        If `True` then an integration failure will raise a runtime error.
 
         If `False` then the returned solution object will have a `result` field
         indicating whether any failures occurred.
@@ -769,6 +868,25 @@ def diffeqsolve(
     #
     # Initial set-up
     #
+
+    # Backward compatibility
+    if discrete_terminating_event is not None:
+        warnings.warn(
+            "`diffrax.diffeqsolve(..., discrete_terminating_event=...)` is deprecated "
+            "in favour of the more general `diffrax.diffeqsolve(..., event=...)` "
+            "interface. This will be removed in some future version of Diffrax.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        if event is None:
+            event = Event(
+                cond_fn=DiscreteTerminatingEventToCondFn(discrete_terminating_event)
+            )
+        else:
+            raise ValueError(
+                "Cannot pass both "
+                "`diffrax.diffeqsolve(..., event=..., discrete_terminating_event=...)`."
+            )
 
     # Error checking
     if dt0 is not None:
@@ -1017,49 +1135,97 @@ def diffeqsolve(
     num_rejected_steps = 0
     made_jump = False if made_jump is None else made_jump
     result = RESULTS.successful
+    if saveat.dense or event is not None:
+        _, _, dense_info_struct, _, _ = eqx.filter_eval_shape(
+            solver.step, terms, tprev, tnext, y0, args, solver_state, made_jump
+        )
     if saveat.dense:
         if max_steps is None:
             raise ValueError(
                 "`max_steps=None` is incompatible with `saveat.dense=True`"
             )
-        (
-            _,
-            _,
-            dense_info,
-            _,
-            _,
-        ) = eqx.filter_eval_shape(
-            solver.step, terms, tprev, tnext, y0, args, solver_state, made_jump
-        )
         dense_ts = jnp.full(max_steps + 1, jnp.inf, dtype=time_dtype)
         _make_full = lambda x: jnp.full(
             (max_steps,) + jnp.shape(x), jnp.inf, dtype=x.dtype
         )
-        dense_infos = jtu.tree_map(_make_full, dense_info)
+        dense_infos = jtu.tree_map(_make_full, dense_info_struct)  # pyright: ignore[reportPossiblyUnboundVariable]
         dense_save_index = 0
     else:
         dense_ts = None
         dense_infos = None
         dense_save_index = None
 
-    if event is None:
-        tprevprev = None
-        dense_info_for_event = None
-        event_mask = None
-    else:
-        tprevprev = tprev
-        _, _, traced_dense_info_event, _, _ = eqx.filter_eval_shape(
-            solver.step, terms, tprev, tnext, y0, args, solver_state, made_jump
-        )
-        dense_info_for_event = jtu.tree_map(
-            lambda x: jnp.empty(x.shape, x.dtype), traced_dense_info_event
-        )
-        event_mask = jtu.tree_map(
-            lambda x: jnp.bool_(False), event.cond_fn, is_leaf=callable
-        )
-
     # Progress meter
     progress_meter_state = progress_meter.init()
+
+    # Events
+    if event is None:
+        event_tprev = None
+        event_tnext = None
+        event_dense_info = None
+        event_values = None
+        event_mask = None
+    else:
+        event_tprev = tprev
+        event_tnext = tnext
+        # Fill the dense-info with dummy values on the first step, when we haven't yet
+        # made any steps.
+        # Note that we're threading a needle here! What if we terminate on the very
+        # first step? Our dense-info (and thus a subsequent root find) will be
+        # completely wrong!
+        # Fortunately, this can't quite happen:
+        # - A boolean event never uses dense-info (the interpolation is unused and we go
+        #   to the end of the interval).
+        # - A floating event can't terminate on the first step (it requires a sign
+        #   change).
+        event_dense_info = jtu.tree_map(
+            lambda x: jnp.empty(x.shape, x.dtype),
+            dense_info_struct,  # pyright: ignore[reportPossiblyUnboundVariable]
+        )
+
+        event_values = jtu.tree_map(
+            lambda cond_fn_i: cond_fn_i(
+                tprev,
+                y0,
+                args,
+                terms=terms,
+                solver=solver,
+                t0=t0,
+                t1=t1,
+                dt0=dt0,
+                saveat=saveat,
+                stepsize_controller=stepsize_controller,
+                max_steps=max_steps,
+            ),
+            event.cond_fn,
+            is_leaf=callable,
+        )
+
+        had_event = False
+        event_values_leaves, event_structure = jtu.tree_flatten(event_values)
+        event_mask_leaves = []
+        for event_value_i in event_values_leaves:
+            if jnp.shape(event_value_i) != ():
+                raise ValueError(
+                    "Event functions must return a scalar, got shape "
+                    f"{jnp.shape(event_value_i)}."
+                )
+            event_dtype = jnp.result_type(event_value_i)
+            if jnp.issubdtype(event_dtype, jnp.floating):
+                event_mask_i = False  # Has not yet had the opportunity to change sign.
+            elif jnp.issubdtype(event_dtype, jnp.bool_):
+                event_mask_i = event_value_i
+            else:
+                assert False
+            event_mask_leaves.append(event_mask_i & jnp.invert(had_event))
+            had_event = event_mask_i | had_event
+        event_mask = jtu.tree_unflatten(event_structure, event_mask_leaves)
+        result = RESULTS.where(
+            had_event,
+            RESULTS.terminating_event_occurred,
+            result,
+        )
+        del had_event, event_values_leaves, event_structure, event_mask_leaves
 
     # Initialise state
     init_state = State(
@@ -1078,34 +1244,12 @@ def diffeqsolve(
         dense_infos=dense_infos,
         dense_save_index=dense_save_index,
         progress_meter_state=progress_meter_state,
-        tprevprev=tprevprev,
-        dense_info_for_event=dense_info_for_event,
-        event_result=None,
+        event_tprev=event_tprev,
+        event_tnext=event_tnext,
+        event_dense_info=event_dense_info,
+        event_values=event_values,
         event_mask=event_mask,
     )
-
-    # Since cond_fn might depend on the state, we need to initialise event_result here.
-    if event is not None:
-
-        def _call_event(_cond_fn):
-            return _cond_fn(
-                init_state,
-                y=y0,
-                solver=solver,
-                stepsize_controller=stepsize_controller,
-                saveat=saveat,
-                t0=t0,
-                t1=t1,
-                dt0=dt0,
-                max_steps=max_steps,
-                terms=terms,
-                args=args,
-            )
-
-        event_result = jtu.tree_map(_call_event, event.cond_fn, is_leaf=callable)
-        init_state = eqx.tree_at(
-            lambda s: s.event_result, init_state, event_result, is_leaf=_is_none
-        )
 
     #
     # Main loop
@@ -1141,75 +1285,9 @@ def diffeqsolve(
     )
     ys = jtu.tree_map(lambda s: s.ys, final_state.save_state, is_leaf=is_save_state)
 
-    # Do root find for exact event times
-    if event is not None:
-        event_mask = final_state.event_mask
-        event_happened = _event_happened(event_mask)
-        interpolator = solver.interpolation_cls(
-            t0=final_state.tprevprev,
-            t1=final_state.tprev,
-            **final_state.dense_info_for_event,
-        )
-        if event.root_finder is None:
-            tevent = final_state.tprev
-        else:
-
-            def _to_root_find(t, args):
-                def _call_real(cond_fn_i, event_mask_i):
-                    y = interpolator.evaluate(t)
-                    result = cond_fn_i(
-                        final_state,
-                        y=y,
-                        solver=solver,
-                        stepsize_controller=stepsize_controller,
-                        saveat=saveat,
-                        t0=t0,
-                        t1=t1,
-                        dt0=dt0,
-                        max_steps=max_steps,
-                        terms=terms,
-                        args=args,
-                    )
-
-                    if jnp.result_type(result) == jnp.bool_:
-                        result = final_state.tprev - t
-                    return jnp.where(event_mask_i, result, 0.0)
-
-                results = jtu.tree_map(
-                    _call_real,
-                    event.cond_fn,
-                    event_mask,
-                    is_leaf=callable,
-                )
-                # If no events are triggered simply push tevent towards tprev
-                results = jtu.tree_map(
-                    lambda x: jnp.where(event_happened, x, final_state.tprev - t),
-                    results,
-                )
-                return results
-
-            options = {"lower": final_state.tprevprev, "upper": final_state.tprev}
-            roots = optx.root_find(
-                _to_root_find, event.root_finder, y0=final_state.tprev, options=options
-            )
-            tevent = roots.value
-
-        # We might need to change this in order to get more accurate derivatives
-        yevent = interpolator.evaluate(tevent)
-
-        def _save_yevent(subsaveat: SubSaveAt, y):
-            return jtu.tree_map(
-                lambda s, _y: _y.at[-1].set(s), subsaveat.fn(tevent, yevent, args), y
-            )
-
-        ys = jtu.tree_map(_save_yevent, saveat.subs, ys, is_leaf=_is_subsaveat)
-        ts = jtu.tree_map(lambda _t: _t.at[-1].set(tevent), ts)
-    else:
-        event_mask = None
-
     # It's important that we don't do any further postprocessing on `ys` here, as
     # it is the `final_state` value that is used when backpropagating via
-    # optimise-then-discretise.
+    # `BacksolveAdjoint`.
 
     if saveat.controller_state:
         controller_state = final_state.controller_state
@@ -1245,8 +1323,10 @@ def diffeqsolve(
         "num_accepted_steps": final_state.num_accepted_steps,
         "num_rejected_steps": final_state.num_rejected_steps,
         "max_steps": max_steps,
+        **aux_stats,
     }
     result = final_state.result
+    event_mask = final_state.event_mask
     sol = Solution(
         t0=t0,
         t1=t1,

--- a/diffrax/_step_size_controller/adaptive.py
+++ b/diffrax/_step_size_controller/adaptive.py
@@ -602,8 +602,8 @@ class PIDController(
         factormin = jnp.where(keep_step, 1, self.factormin)
         factor = jnp.clip(
             self.safety * factor1 * factor2 * factor3,
-            a_min=factormin,
-            a_max=self.factormax,
+            min=factormin,
+            max=self.factormax,
         )
         # Once again, see above. In case we have gradients on {i,p,d}coeff.
         # (Probably quite common for them to have zero tangents if passed across

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,24 +1,10 @@
 # Events
 
-Events allow for interrupting a differential equation solve, and changing its internal state, or terminating the solve before `t1` is reached.
+Events allow for interrupting a differential equation solve, by terminating the solve before `t1` is reached.
 
-At the moment a single kind of event is supported: discrete events which are checked at the end of every step, and which halt the integration once they become true.
-
-??? abstract "`diffrax.AbstractDiscreteTerminatingEvent`"
-
-    ::: diffrax.AbstractDiscreteTerminatingEvent
-        selection:
-            members:
-                - __call__
-
----
-
-::: diffrax.DiscreteTerminatingEvent
+::: diffrax.Event
     selection:
         members:
             - __init__
 
-::: diffrax.SteadyStateEvent
-    selection:
-        members:
-            - __init__
+::: diffrax.steady_state_event

--- a/test/test_adjoint.py
+++ b/test/test_adjoint.py
@@ -258,13 +258,13 @@ def test_closure_fixed():
     run(mlp)
 
 
-@pytest.mark.skip(reason="SteadyStateEvent discontinued")
 def test_implicit():
     class ExponentialDecayToSteadyState(eqx.Module):
         steady_state: Array
         non_jax_type: Any
 
         def __call__(self, t, y, args):
+            del t, args
             return self.steady_state - y
 
     def loss(model, target_steady_state):
@@ -276,7 +276,7 @@ def test_implicit():
         y0 = 1.0
         max_steps = None
         controller = diffrax.PIDController(rtol=1e-3, atol=1e-6)
-        event = diffrax.SteadyStateEvent()  # pyright: ignore
+        event = diffrax.SteadyStateEvent()
         adjoint = diffrax.ImplicitAdjoint()
         sol = diffrax.diffeqsolve(
             term,
@@ -287,7 +287,7 @@ def test_implicit():
             y0,
             max_steps=max_steps,
             stepsize_controller=controller,
-            discrete_terminating_event=event,  # pyright: ignore
+            discrete_terminating_event=event,
             adjoint=adjoint,
         )
         (y1,) = cast(Array, sol.ys)


### PR DESCRIPTION
This PR goes through and organises some of the event-handling code. The full list of changes is:

- Semantic change: boolean events now trigger when they become truthy (before they occurred when they swap being falsy<->truthy). Note that this required twiddling around a few things as previously it was impossible for an event to trigger on the first step; now they can.
- Semantic change: event functions now have the signature `(t, y, args *, terms, solver, **etc)` for consistency with vector fields and with `SaveAt(fn=...)`.
- Feature: now backward-compatible with the old discrete terminating events.
- Feature: added `diffrax.steady_state_event`.
- Bugfix: the final `t` and `y` from an event are now saved in the correct index of `ts` and `ys`, rather than just always being saved at index `-1`.
- Bugfix: at one point `args` referred to the `args` coming from a root find rather than the overall `diffeqsolve`.
- Bugfix: the current `state.tprev` was used instead of the previous state's `tnext`. (These are usually but not always the same -- in particular when around jumps.)
- Bugfix: added some checks when the condition function of an event does not return a bool/float scalar.
- Performance: includes a fastpath for skipping the rootfind if no events are triggered.
- Performance: now avoiding tracing for the shape of `dense_info` twice when using adaptive step size controllers alongside events.
- Performance: avoided quadratic loop for figuring out what was the first event to trigger.
- Chore: added support for the possibility of the final root find (for the time of the event) failing.
- Chore: removed some dead code (`_bool_event_gradient`).
- Chore: removed references in the docs to the old `discrete_terminating_event`.

---

In addition, some drive-bys:

- Fixed warnings about pending deprecations `jnp.clip(..., a_min=..., a_max=...)`.
- Had `aux_stats` (in `_integrate.py`) forward to the overall output statistics. In practice this is empty but it's worth doing for the future.

---

Before we can merge this into Diffrax's main branch, there are still some things that need doing -- @cholberg are you able to handle these?

- Add a docstring for `Event`;
- Add an example to `events.md` demonstrating how to use `Event`;
- Update the existing steady-state example to use the new syntax;
- Add several tests:
    - For `steady_state_event`;
    - That things behave correctly when a boolean event stops us before we even perform a single step;
    - Events in combination with adaptive stepping;
    - Events in combination with `vmap` (down various different parameters: `t`, `y`, and even the definition of the event itself!)
    - Events in combination with both adaptive stepping and vmap;
    - Events that are malformed from the user: that we error out appropriately when provided events that return non-scalars, or that return integers, or that return complex numbers.
    - When using more complicated choice of `SaveAt`. For example the previous implementation saved results into index `-1`, which is incorrect in general (e.g. if we have `SaveAt(steps=True)` then we allocate a buffer of length `max_steps`, and only expect to partially fill it).

---

I've tested that this passes all of `test_event.py` (including all the old ones for discrete terminating events), but haven't checked over every test in Diffrax -- it's possible that I've missed something elsewhere.