### PR TITLE
Doc tweaks for events

### DIFF
--- a/diffrax/_integrate.py
+++ b/diffrax/_integrate.py
@@ -563,7 +563,7 @@ def loop(
             event_mask = jtu.tree_unflatten(event_structure, event_mask_leaves)
             result = RESULTS.where(
                 had_event,
-                RESULTS.terminating_event_occurred,
+                RESULTS.event_occurred,
                 result,
             )
 
@@ -679,7 +679,7 @@ def loop(
                     # to avoid this, I think.
                     _value = lax.cond(_event_mask_i, _call_real_impl, lambda: 0.0)
 
-                    # Third: if no events triggered at all, then has the root occur at
+                    # Third: if no events triggered at all, then have the root occur at
                     # the end of the last step (which will be the `t1` of the overall
                     # solve).
                     _value = jnp.where(event_happened, _value, _distance_from_t_end)
@@ -1332,7 +1332,7 @@ def diffeqsolve(
         event_mask = jtu.tree_unflatten(event_structure, event_mask_leaves)
         result = RESULTS.where(
             had_event,
-            RESULTS.terminating_event_occurred,
+            RESULTS.event_occurred,
             result,
         )
         del had_event, event_structure, event_mask_leaves, event_values__mask

--- a/diffrax/_solution.py
+++ b/diffrax/_solution.py
@@ -18,7 +18,7 @@ class RESULTS(optx.RESULTS):  # pyright: ignore
     dt_min_reached = (
         "The minimum step size was reached in the differential equation solver."
     )
-    terminating_event_occurred = (
+    event_occurred = (
         "Terminating differential equation solve because an event occurred."
     )
 
@@ -32,9 +32,10 @@ def discrete_terminating_event_occurred(self):
     warnings.warn(
         "`diffrax.RESULTS.discrete_terminating_event_occurred` is deprecated in "
         "favour of `diffrax.RESULTS.terminating_event_occurred`. This will be "
-        "removed in some future version of Diffrax."
+        "removed in some future version of Diffrax.",
+        stacklevel=2,
     )
-    return self.terminating_event_occurred
+    return self.event_occurred
 
 
 RESULTS.discrete_terminating_event_occurred = discrete_terminating_event_occurred  # pyright: ignore[reportAttributeAccessIssue]
@@ -49,10 +50,8 @@ def is_successful(result: RESULTS) -> Bool[Array, ""]:
     return result == RESULTS.successful
 
 
-# TODO: In the future we may support other event types, in which case this function
-# should be updated.
 def is_event(result: RESULTS) -> Bool[Array, ""]:
-    return result == RESULTS.terminating_event_occurred
+    return result == RESULTS.event_occurred
 
 
 def update_result(old_result: RESULTS, new_result: RESULTS) -> RESULTS:
@@ -84,10 +83,9 @@ class Solution(AbstractPath):
     - `ys`: The value of the solution at each of the times in `ts`. Might `None` if no
         values were saved.
     - `stats`: Statistics for the solve (number of steps etc.).
-    - `result`: Integer specifying the success or cause of failure of the solve. A
-        value of `0` corresponds to a successful solve. Any other value is a failure.
-        A human-readable message can be obtained by looking up messages via
-        `diffrax.RESULTS[<integer>]`.
+    - `result`: A [`diffrax.RESULT`][] specifying the success or cause of failure of the
+        solve. A human-readable message is displayed if printed. No message means
+        success!
     - `solver_state`: If saved, the final internal state of the numerical solver.
     - `controller_state`: If saved, the final internal state for the step size
         controller.

--- a/docs/api/solution.md
+++ b/docs/api/solution.md
@@ -15,3 +15,9 @@
             - message
             - evaluate
             - derivative
+
+---
+
+::: diffrax.RESULTS
+    selection:
+        members: false


### PR DESCRIPTION
Doing a review of https://github.com/patrick-kidger/diffrax/pull/387 -- tidied up many doc things. (And also renamed `RESULTS.terminating_event_occurred -> event_occurred` for further simplicity.